### PR TITLE
fix: :bug: configuration syntax fix.

### DIFF
--- a/src/jetpack/config.py
+++ b/src/jetpack/config.py
@@ -11,7 +11,7 @@ class _LogConfig(BaseSettings):
     ENABLE_FILE_LOG: Optional[bool] = False
     ENABLE_CONSOLE_LOG: Optional[bool] = True
     LOG_ENABLE_TRACEBACK: bool = Field(default=False)
-    DEFER_LOG_MODULES = Optional[list] = ["httpx", "pymongo"]
+    DEFER_LOG_MODULES: Optional[list] = ["httpx", "pymongo"]
     DEFER_ADDITIONAL_LOGS = Optional[list] = []
     DEFER_LOG_LEVEL: str = "INFO"
 


### PR DESCRIPTION
This pull request includes a small change to the `src/jetpack/config.py` file. The change corrects the type annotation for the `DEFER_LOG_MODULES` attribute in the `_LogConfig` class.

* [`src/jetpack/config.py`](diffhunk://#diff-39083f4cb08d3522c79daa53afffbec967f398bc7c714f86430afdc03fddca0bL14-R14): Corrected the type annotation for `DEFER_LOG_MODULES` from `DEFER_LOG_MODULES = Optional[list]` to `DEFER_LOG_MODULES: Optional[list]`.