### PR TITLE
Bump version to 0.1.1 and fix logging configuration syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jetpack"
-version = "0.1.0"
+version = "0.1.1"
 description = "Project Utilities to kickstart a micro-service."
 readme = "README.md"
 authors = [

--- a/src/jetpack/config.py
+++ b/src/jetpack/config.py
@@ -12,7 +12,7 @@ class _LogConfig(BaseSettings):
     ENABLE_CONSOLE_LOG: Optional[bool] = True
     LOG_ENABLE_TRACEBACK: bool = Field(default=False)
     DEFER_LOG_MODULES: Optional[list] = ["httpx", "pymongo"]
-    DEFER_ADDITIONAL_LOGS = Optional[list] = []
+    DEFER_ADDITIONAL_LOGS: Optional[list] = []
     DEFER_LOG_LEVEL: str = "INFO"
 
 


### PR DESCRIPTION
Update the project version to 0.1.1 and correct the syntax in the logging configuration.